### PR TITLE
tests: expand test suite, fix benchmark time layout, fix fewer-tokens panic

### DIFF
--- a/bench_extended_test.go
+++ b/bench_extended_test.go
@@ -1,0 +1,313 @@
+package hunkee
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// === Benchmark types ===
+
+type benchStr1 struct {
+	Name string `hunk:"name"`
+}
+
+type benchStr5 struct {
+	A string `hunk:"a"`
+	B string `hunk:"b"`
+	C string `hunk:"c"`
+	D string `hunk:"d"`
+	E string `hunk:"e"`
+}
+
+type bench15 struct {
+	F1  string  `hunk:"f1"`
+	F2  int     `hunk:"f2"`
+	F3  uint64  `hunk:"f3"`
+	F4  string  `hunk:"f4"`
+	F5  float64 `hunk:"f5"`
+	F6  string  `hunk:"f6"`
+	F7  int     `hunk:"f7"`
+	F8  string  `hunk:"f8"`
+	F9  uint32  `hunk:"f9"`
+	F10 string  `hunk:"f10"`
+	F11 int64   `hunk:"f11"`
+	F12 string  `hunk:"f12"`
+	F13 uint16  `hunk:"f13"`
+	F14 float32 `hunk:"f14"`
+	F15 string  `hunk:"f15"`
+}
+
+type bench25 struct {
+	F1  string `hunk:"f1"`
+	F2  string `hunk:"f2"`
+	F3  string `hunk:"f3"`
+	F4  string `hunk:"f4"`
+	F5  string `hunk:"f5"`
+	F6  string `hunk:"f6"`
+	F7  string `hunk:"f7"`
+	F8  string `hunk:"f8"`
+	F9  string `hunk:"f9"`
+	F10 string `hunk:"f10"`
+	F11 string `hunk:"f11"`
+	F12 string `hunk:"f12"`
+	F13 string `hunk:"f13"`
+	F14 string `hunk:"f14"`
+	F15 string `hunk:"f15"`
+	F16 string `hunk:"f16"`
+	F17 string `hunk:"f17"`
+	F18 string `hunk:"f18"`
+	F19 string `hunk:"f19"`
+	F20 string `hunk:"f20"`
+	F21 string `hunk:"f21"`
+	F22 string `hunk:"f22"`
+	F23 string `hunk:"f23"`
+	F24 string `hunk:"f24"`
+	F25 string `hunk:"f25"`
+}
+
+type benchAllInts struct {
+	A int   `hunk:"a"`
+	B int64 `hunk:"b"`
+	C int32 `hunk:"c"`
+	D int16 `hunk:"d"`
+	E int   `hunk:"e"`
+}
+
+type benchMixed struct {
+	I int     `hunk:"i"`
+	U uint64  `hunk:"u"`
+	F float64 `hunk:"f"`
+	S string  `hunk:"s"`
+	B bool    `hunk:"b"`
+}
+
+type benchTimeHeavy struct {
+	T1 time.Time `hunk:"t1"`
+	T2 time.Time `hunk:"t2"`
+	T3 time.Time `hunk:"t3"`
+	T4 time.Time `hunk:"t4"`
+	T5 time.Time `hunk:"t5"`
+}
+
+// === Benchmark data ===
+
+var (
+	fmt1     = ":name"
+	entry1   = "Brighton"
+	fmt5     = ":a :b :c :d :e"
+	entry5   = "alpha beta gamma delta epsilon"
+	fmt15    = ":f1 :f2 :f3 :f4 :f5 :f6 :f7 :f8 :f9 :f10 :f11 :f12 :f13 :f14 :f15"
+	entry15  = "alpha 42 99999 beta 3.14 gamma 7 delta 12345 epsilon 9876543210 zeta 1024 2.718 omega"
+	fmt25    = ":f1 :f2 :f3 :f4 :f5 :f6 :f7 :f8 :f9 :f10 :f11 :f12 :f13 :f14 :f15 :f16 :f17 :f18 :f19 :f20 :f21 :f22 :f23 :f24 :f25"
+	entry25  = "alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau upsilon phi chi psi omega terminus"
+	fmtInts  = ":a :b :c :d :e"
+	entInts  = "42 1234567890 9999 100 77"
+	fmtMixed = ":i :u :f :s :b"
+	entMixed = "42 99999 3.14159 hello true"
+	fmtTime  = ":t1 :t2 :t3 :t4 :t5"
+	entTime  = "2024-01-15T10:30:00Z 2024-02-20T14:45:30Z 2024-03-25T08:15:00Z 2024-04-01T23:59:59Z 2024-05-10T12:00:00Z"
+)
+
+// === Field count benchmarks ===
+
+func BenchmarkParseByFieldCount(b *testing.B) {
+	b.Run("1", func(b *testing.B) {
+		b.ReportAllocs()
+		v := new(benchStr1)
+		p, err := NewParser(fmt1, v)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := p.ParseLine(entry1, v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("5", func(b *testing.B) {
+		b.ReportAllocs()
+		v := new(benchStr5)
+		p, err := NewParser(fmt5, v)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := p.ParseLine(entry5, v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("15", func(b *testing.B) {
+		b.ReportAllocs()
+		v := new(bench15)
+		p, err := NewParser(fmt15, v)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := p.ParseLine(entry15, v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("25", func(b *testing.B) {
+		b.ReportAllocs()
+		v := new(bench25)
+		p, err := NewParser(fmt25, v)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := p.ParseLine(entry25, v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// === Type complexity benchmarks ===
+
+func BenchmarkParseByTypeComplexity(b *testing.B) {
+	b.Run("AllStrings", func(b *testing.B) {
+		b.ReportAllocs()
+		v := new(benchStr5)
+		p, err := NewParser(fmt5, v)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := p.ParseLine(entry5, v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("AllInts", func(b *testing.B) {
+		b.ReportAllocs()
+		v := new(benchAllInts)
+		p, err := NewParser(fmtInts, v)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := p.ParseLine(entInts, v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Mixed", func(b *testing.B) {
+		b.ReportAllocs()
+		v := new(benchMixed)
+		p, err := NewParser(fmtMixed, v)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := p.ParseLine(entMixed, v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("TimeHeavy", func(b *testing.B) {
+		b.ReportAllocs()
+		v := new(benchTimeHeavy)
+		p, err := NewParser(fmtTime, v)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := p.ParseLine(entTime, v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// === Line length benchmarks ===
+
+func BenchmarkParseByLineLength(b *testing.B) {
+	shortEntry := "hello world foo bar baz"
+	mediumEntry := strings.Repeat("a", 40) + " " + strings.Repeat("b", 40) + " " +
+		strings.Repeat("c", 40) + " " + strings.Repeat("d", 40) + " " + strings.Repeat("e", 40)
+	longEntry := strings.Repeat("a", 200) + " " + strings.Repeat("b", 200) + " " +
+		strings.Repeat("c", 200) + " " + strings.Repeat("d", 200) + " " + strings.Repeat("e", 200)
+
+	b.Run("Short_23B", func(b *testing.B) {
+		b.ReportAllocs()
+		v := new(benchStr5)
+		p, err := NewParser(fmt5, v)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := p.ParseLine(shortEntry, v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Medium_204B", func(b *testing.B) {
+		b.ReportAllocs()
+		v := new(benchStr5)
+		p, err := NewParser(fmt5, v)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := p.ParseLine(mediumEntry, v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("Long_1004B", func(b *testing.B) {
+		b.ReportAllocs()
+		v := new(benchStr5)
+		p, err := NewParser(fmt5, v)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			if err := p.ParseLine(longEntry, v); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// === Concurrent benchmark ===
+
+func BenchmarkParseConcurrent(b *testing.B) {
+	b.ReportAllocs()
+	v := new(benchMixed)
+	p, err := NewParser(fmtMixed, v)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		local := new(benchMixed)
+		for pb.Next() {
+			if err := p.ParseLine(entMixed, local); err != nil {
+				b.Error(err)
+			}
+		}
+	})
+}

--- a/extractors.go
+++ b/extractors.go
@@ -44,6 +44,10 @@ func (p *Parser) parseLine(line string, dest interface{}) (err error) {
 	for field := w.first(); field != nil; field = w.next() {
 		var token string
 
+		if offset < 0 {
+			return errors.New("provided line has less tokens than expected")
+		}
+
 		start := offset
 		// if token separator is 0, no need to search first occurrence
 		if p.mapper.tokenSep != 0 {

--- a/hunkee_bench_test.go
+++ b/hunkee_bench_test.go
@@ -19,14 +19,14 @@ type Beach struct {
 var (
 	parser     *Parser
 	bch        = new(Beach)
-	timeLayout = time.RFC822
+	timeLayout = time.RFC3339
 	format     = ":time :id :name :lo_ac :temp"
-	entry      = "02 Jan 06 15:04 MST 17522 Brighton 20 25.6"
+	entry      = "2018-07-28T21:10:45Z 17522 Brighton 20 25.6"
 
 	formatWithoutTime = ":id :name :lo_ac :temp"
 	entryWithoutTime  = "17522 Brighton 20 25.6"
 
-	LogRecordRegex   = regexp.MustCompile(`^(\d{2}\s[A-Z][a-z]{2}\s[0-9]{2}\s[0-9]{2}:[0-9]{2})\s([A-Z]{3})\s+(\d)+\s+(\w)+\s+(\d{2})\s+([0-9]+\.\d+)$`)
+	LogRecordRegex   = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)\s+(\d+)\s+(\w+)\s+(\d+)\s+([0-9]+\.\d+)$`)
 	LogRecordWTRegex = regexp.MustCompile(`^(\d{5})+\s+(\w)+\s+(\d{2})\s+([0-9]+\.\d+)$`)
 )
 
@@ -64,14 +64,14 @@ func BenchmarkParseRE(b *testing.B) {
 	bch := new(Beach)
 	for i := 0; i < b.N; i++ {
 		tokens := LogRecordRegex.FindStringSubmatch(entry)
-		u16, _ := strconv.ParseUint(tokens[1], 10, 16)
+		bch.Time, _ = time.Parse(timeLayout, tokens[1])
+		u16, _ := strconv.ParseUint(tokens[2], 10, 16)
 		bch.ID = uint16(u16)
-		bch.Name = tokens[2]
-		u8, _ := strconv.ParseUint(tokens[3], 10, 8)
+		bch.Name = tokens[3]
+		u8, _ := strconv.ParseUint(tokens[4], 10, 8)
 		bch.LoAc = uint8(u8)
-		f32, _ := strconv.ParseFloat(tokens[4], 32)
+		f32, _ := strconv.ParseFloat(tokens[5], 32)
 		bch.Temp = float32(f32)
-		bch.Time, _ = time.Parse(timeLayout, tokens[0])
 	}
 }
 

--- a/hunkee_extended_test.go
+++ b/hunkee_extended_test.go
@@ -1,0 +1,519 @@
+package hunkee
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// === 1. Edge Cases & Robustness Tests ===
+
+// TestParseLine_DashAsNull_IntField verifies that "-" token into an int field
+// produces zero value with no error, matching nginx/CDN log conventions where
+// dash represents missing values.
+func TestParseLine_DashAsNull_IntField(t *testing.T) {
+	var s struct {
+		Status int    `hunk:"status"`
+		Name   string `hunk:"name"`
+	}
+	p, err := NewParser(":status :name", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+	if err := p.ParseLine("- hello", &s); err != nil {
+		t.Fatalf("unexpected parse error: %s", err)
+	}
+	if s.Status != 0 {
+		t.Errorf("int with dash: expected 0, got %d", s.Status)
+	}
+	if s.Name != "hello" {
+		t.Errorf("name: expected 'hello', got %q", s.Name)
+	}
+}
+
+// TestParseLine_DashAsNull_MultipleTypes verifies that "-" into uint, float, bool,
+// IP, and string fields produces appropriate zero/default values.
+func TestParseLine_DashAsNull_MultipleTypes(t *testing.T) {
+	var s struct {
+		U  uint64  `hunk:"u"`
+		F  float64 `hunk:"f"`
+		B  bool    `hunk:"b"`
+		IP net.IP  `hunk:"ip"`
+		S  string  `hunk:"s"`
+	}
+	p, err := NewParser(":u :f :b :ip :s", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+	if err := p.ParseLine("- - - - -", &s); err != nil {
+		t.Fatalf("unexpected parse error: %s", err)
+	}
+	if s.U != 0 {
+		t.Errorf("uint: expected 0 for dash, got %d", s.U)
+	}
+	if s.F != 0 {
+		t.Errorf("float: expected 0 for dash, got %f", s.F)
+	}
+	if s.B != false {
+		t.Errorf("bool: expected false for dash, got %t", s.B)
+	}
+	if s.IP != nil {
+		t.Errorf("IP: expected nil for dash, got %v", s.IP)
+	}
+	// String fields get "-" literally, not zero value
+	if s.S != "-" {
+		t.Errorf("string: expected '-' for dash, got %q", s.S)
+	}
+}
+
+// TestParseLine_EmptyToken_NumericTypes verifies that empty tokens for int/uint/float
+// produce zero values with no error (guarded by `token != ""` check in processField).
+func TestParseLine_EmptyToken_NumericTypes(t *testing.T) {
+	var s struct {
+		I int     `hunk:"i"`
+		U uint64  `hunk:"u"`
+		F float64 `hunk:"f"`
+	}
+	p, err := NewParser(":i :u :f", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+	p.SetTokenSeparator('"')
+
+	// All tokens are empty strings between quotes
+	if err := p.ParseLine(`"" "" ""`, &s); err != nil {
+		t.Fatalf("unexpected parse error for empty tokens: %s", err)
+	}
+	if s.I != 0 {
+		t.Errorf("int: expected 0 for empty token, got %d", s.I)
+	}
+	if s.U != 0 {
+		t.Errorf("uint: expected 0 for empty token, got %d", s.U)
+	}
+	if s.F != 0 {
+		t.Errorf("float: expected 0 for empty token, got %f", s.F)
+	}
+}
+
+// TestParseLine_EmptyToken_BoolError verifies that an empty token for a bool
+// field produces an error (no `token != ""` guard exists for bool in processField).
+func TestParseLine_EmptyToken_BoolError(t *testing.T) {
+	var s struct {
+		B bool `hunk:"b"`
+	}
+	p, err := NewParser(":b", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+	p.SetTokenSeparator('"')
+
+	err = p.ParseLine(`""`, &s)
+	if err == nil {
+		t.Fatal("expected error for empty bool token, got nil")
+	}
+}
+
+// TestParseLine_Overflow_Uint8 verifies that parsing "256" into a uint8 field
+// returns a range error (max uint8 is 255).
+func TestParseLine_Overflow_Uint8(t *testing.T) {
+	var s struct {
+		V uint8 `hunk:"v"`
+	}
+	p, err := NewParser(":v", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+	err = p.ParseLine("256", &s)
+	if err == nil {
+		t.Fatal("expected range error for uint8=256, got nil")
+	}
+	if !strings.Contains(err.Error(), "range") {
+		t.Errorf("expected range error, got: %s", err)
+	}
+}
+
+// TestParseLine_Overflow_Int8 verifies that parsing "128" into an int8 field
+// returns a range error (max int8 is 127).
+func TestParseLine_Overflow_Int8(t *testing.T) {
+	var s struct {
+		V int8 `hunk:"v"`
+	}
+	p, err := NewParser(":v", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+	err = p.ParseLine("128", &s)
+	if err == nil {
+		t.Fatal("expected range error for int8=128, got nil")
+	}
+	if !strings.Contains(err.Error(), "range") {
+		t.Errorf("expected range error, got: %s", err)
+	}
+}
+
+// TestParseLine_VeryLongString verifies that a 10KB+ token does not cause
+// panics or OOM.
+func TestParseLine_VeryLongString(t *testing.T) {
+	var s struct {
+		Name string `hunk:"name"`
+	}
+	p, err := NewParser(":name", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+	longVal := strings.Repeat("x", 10240) // 10KB
+	if err := p.ParseLine(longVal, &s); err != nil {
+		t.Fatalf("unexpected error for long string: %s", err)
+	}
+	if len(s.Name) != 10240 {
+		t.Errorf("expected length 10240, got %d", len(s.Name))
+	}
+}
+
+// TestParseLine_MultipleConsecutiveSpaces documents that consecutive spaces
+// cause empty tokens for intermediate fields (the parser treats each space
+// as a separator boundary).
+func TestParseLine_MultipleConsecutiveSpaces(t *testing.T) {
+	var s struct {
+		A string `hunk:"a"`
+		B string `hunk:"b"`
+		C string `hunk:"c"`
+	}
+	p, err := NewParser(":a :b :c", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+
+	// Double space between "hello" and "world" means field B gets an empty
+	// token from the adjacent space characters.
+	if err := p.ParseLine("hello  world", &s); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if s.A != "hello" {
+		t.Errorf("field A: expected 'hello', got %q", s.A)
+	}
+	if s.B != "" {
+		t.Errorf("field B: expected empty string (double space), got %q", s.B)
+	}
+	if s.C != "world" {
+		t.Errorf("field C: expected 'world', got %q", s.C)
+	}
+}
+
+// === 2. Token Count Mismatch Tests ===
+
+// TestParseLine_FewerTokensThanFormat verifies that a line with fewer tokens
+// than the format expects returns an error instead of panicking.
+// Bug fix: prior to the offset<0 guard in extractors.go, this would panic
+// with a negative slice index.
+func TestParseLine_FewerTokensThanFormat(t *testing.T) {
+	var s struct {
+		A string `hunk:"a"`
+		B string `hunk:"b"`
+		C string `hunk:"c"`
+	}
+	p, err := NewParser(":a :b :c", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+
+	err = p.ParseLine("hello world", &s)
+	if err == nil {
+		t.Fatal("expected error for fewer tokens than format, got nil")
+	}
+	if !strings.Contains(err.Error(), "less tokens") {
+		t.Errorf("expected 'less tokens' error, got: %s", err)
+	}
+}
+
+// TestParseLine_MoreTokensThanFormat verifies that extra tokens in the line
+// are silently ignored — only the fields defined in the format are parsed.
+func TestParseLine_MoreTokensThanFormat(t *testing.T) {
+	var s struct {
+		A string `hunk:"a"`
+		B string `hunk:"b"`
+	}
+	p, err := NewParser(":a :b", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+
+	err = p.ParseLine("hello world extra tokens here", &s)
+	if err != nil {
+		t.Fatalf("expected no error for extra tokens, got: %s", err)
+	}
+	if s.A != "hello" {
+		t.Errorf("expected 'hello', got %q", s.A)
+	}
+	if s.B != "world" {
+		t.Errorf("expected 'world', got %q", s.B)
+	}
+}
+
+// TestParseLine_FewerTokensWithSeparator verifies that fewer tokens with a
+// custom separator also returns an error (not a panic).
+func TestParseLine_FewerTokensWithSeparator(t *testing.T) {
+	var s struct {
+		A string `hunk:"a"`
+		B string `hunk:"b"`
+		C string `hunk:"c"`
+	}
+	p, err := NewParser(":a :b :c", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+	p.SetTokenSeparator('"')
+
+	err = p.ParseLine(`"hello" "world"`, &s)
+	if err == nil {
+		t.Fatal("expected error for fewer tokens with separator, got nil")
+	}
+	if !strings.Contains(err.Error(), "less tokens") {
+		t.Errorf("expected 'less tokens' error, got: %s", err)
+	}
+}
+
+// === 3. Separator Variety Tests ===
+
+// TestParseLine_PipeSeparator verifies that pipe '|' works as a wrapping
+// separator, allowing values with spaces inside.
+func TestParseLine_PipeSeparator(t *testing.T) {
+	var s struct {
+		ID   int    `hunk:"id"`
+		Name string `hunk:"name"`
+	}
+	p, err := NewParser(":id :name", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+	p.SetTokenSeparator('|')
+
+	if err := p.ParseLine("|42| |John Doe|", &s); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if s.ID != 42 {
+		t.Errorf("expected ID 42, got %d", s.ID)
+	}
+	if s.Name != "John Doe" {
+		t.Errorf("expected 'John Doe', got %q", s.Name)
+	}
+}
+
+// TestParseLine_TabSeparator verifies that tab can be used as a wrapping
+// separator. Note: hunkee treats the separator as a wrapping character
+// (like quotes), not as a field delimiter (like TSV/CSV).
+func TestParseLine_TabSeparator(t *testing.T) {
+	var s struct {
+		A string `hunk:"a"`
+		B string `hunk:"b"`
+	}
+	p, err := NewParser(":a :b", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+	p.SetTokenSeparator('\t')
+
+	// Values wrapped in tabs, separated by space
+	if err := p.ParseLine("\thello\t \tworld\t", &s); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if s.A != "hello" {
+		t.Errorf("expected 'hello', got %q", s.A)
+	}
+	if s.B != "world" {
+		t.Errorf("expected 'world', got %q", s.B)
+	}
+}
+
+// TestParseLine_SeparatorInsideQuotedValues verifies that the default separator
+// (space) appearing inside quote-wrapped tokens is preserved as part of the value.
+func TestParseLine_SeparatorInsideQuotedValues(t *testing.T) {
+	var s struct {
+		Method string `hunk:"method"`
+		Path   string `hunk:"path"`
+		Agent  string `hunk:"agent"`
+	}
+	p, err := NewParser(":method :path :agent", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+	p.SetTokenSeparator('"')
+
+	if err := p.ParseLine(`"GET" "/index.html" "Mozilla/5.0 (X11; Linux)"`, &s); err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	if s.Method != "GET" {
+		t.Errorf("expected 'GET', got %q", s.Method)
+	}
+	if s.Path != "/index.html" {
+		t.Errorf("expected '/index.html', got %q", s.Path)
+	}
+	if s.Agent != "Mozilla/5.0 (X11; Linux)" {
+		t.Errorf("expected full user agent string, got %q", s.Agent)
+	}
+}
+
+// === 4. Concurrency Tests ===
+
+// TestParseLine_ConcurrentAccess spawns multiple goroutines calling ParseLine
+// on the same Parser instance with individual structs. Run with -race to detect
+// data races in the worker pool.
+func TestParseLine_ConcurrentAccess(t *testing.T) {
+	type entry struct {
+		ID   int    `hunk:"id"`
+		Name string `hunk:"name"`
+	}
+	p, err := NewParser(":id :name", &entry{})
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+	const numGoroutines = 100
+	var wg sync.WaitGroup
+	errs := make(chan error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			var local entry
+			line := fmt.Sprintf("%d name_%d", id, id)
+			if err := p.ParseLine(line, &local); err != nil {
+				errs <- fmt.Errorf("goroutine %d: parse error: %s", id, err)
+				return
+			}
+			if local.ID != id {
+				errs <- fmt.Errorf("goroutine %d: expected ID %d, got %d", id, id, local.ID)
+			}
+			expectedName := fmt.Sprintf("name_%d", id)
+			if local.Name != expectedName {
+				errs <- fmt.Errorf("goroutine %d: expected name %q, got %q", id, expectedName, local.Name)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+// TestParseLine_ConcurrentMixedTypes verifies concurrent parsing with multiple
+// field types doesn't corrupt data across goroutines.
+func TestParseLine_ConcurrentMixedTypes(t *testing.T) {
+	type record struct {
+		ID     uint32  `hunk:"id"`
+		Score  float64 `hunk:"score"`
+		Name   string  `hunk:"name"`
+		Active bool    `hunk:"active"`
+	}
+	p, err := NewParser(":id :score :name :active", &record{})
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+	const N = 200
+	var wg sync.WaitGroup
+	errs := make(chan error, N)
+
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			var r record
+			line := fmt.Sprintf("%d %d.%d item_%d true", id, id, id, id)
+			if err := p.ParseLine(line, &r); err != nil {
+				errs <- fmt.Errorf("goroutine %d: %s", id, err)
+				return
+			}
+			if r.ID != uint32(id) {
+				errs <- fmt.Errorf("goroutine %d: ID mismatch: expected %d, got %d", id, id, r.ID)
+			}
+			if !r.Active {
+				errs <- fmt.Errorf("goroutine %d: Active should be true", id)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Error(err)
+	}
+}
+
+// === 5. Parser Reuse Tests ===
+
+// TestParseLine_ParserReuse_NoStateLeak parses 1500 different lines with one
+// Parser instance and verifies no state leaks between calls.
+func TestParseLine_ParserReuse_NoStateLeak(t *testing.T) {
+	type entry struct {
+		ID   int    `hunk:"id"`
+		Name string `hunk:"name"`
+	}
+	p, err := NewParser(":id :name", &entry{})
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+
+	for i := 0; i < 1500; i++ {
+		var s entry
+		expectedName := fmt.Sprintf("item_%d", i)
+		line := fmt.Sprintf("%d %s", i, expectedName)
+		if err := p.ParseLine(line, &s); err != nil {
+			t.Fatalf("iteration %d: parse error: %s", i, err)
+		}
+		if s.ID != i {
+			t.Fatalf("iteration %d: expected ID %d, got %d", i, i, s.ID)
+		}
+		if s.Name != expectedName {
+			t.Fatalf("iteration %d: expected name %q, got %q", i, expectedName, s.Name)
+		}
+	}
+}
+
+// TestParseLine_StructReuse_CleanOverwrite parses different lines into the
+// same struct and verifies previous values are cleanly overwritten each time.
+func TestParseLine_StructReuse_CleanOverwrite(t *testing.T) {
+	var s struct {
+		ID   int    `hunk:"id"`
+		Name string `hunk:"name"`
+	}
+	p, err := NewParser(":id :name", &s)
+	if err != nil {
+		t.Fatalf("unexpected init error: %s", err)
+	}
+
+	// First parse
+	if err := p.ParseLine("100 alpha", &s); err != nil {
+		t.Fatalf("first parse error: %s", err)
+	}
+	if s.ID != 100 || s.Name != "alpha" {
+		t.Fatalf("first parse: expected {100, alpha}, got {%d, %s}", s.ID, s.Name)
+	}
+
+	// Second parse into same struct — should overwrite
+	if err := p.ParseLine("200 beta", &s); err != nil {
+		t.Fatalf("second parse error: %s", err)
+	}
+	if s.ID != 200 {
+		t.Errorf("struct reuse: ID not overwritten, expected 200, got %d", s.ID)
+	}
+	if s.Name != "beta" {
+		t.Errorf("struct reuse: Name not overwritten, expected 'beta', got %q", s.Name)
+	}
+
+	// Third parse with zero value for ID — verify it doesn't retain old value
+	if err := p.ParseLine("0 gamma", &s); err != nil {
+		t.Fatalf("third parse error: %s", err)
+	}
+	if s.ID != 0 {
+		t.Errorf("struct reuse: ID not overwritten to 0, got %d", s.ID)
+	}
+	if s.Name != "gamma" {
+		t.Errorf("struct reuse: Name not overwritten, expected 'gamma', got %q", s.Name)
+	}
+}


### PR DESCRIPTION
## What

- **18 new tests** in `hunkee_extended_test.go` covering:
  - Edge cases: dash-as-null, empty tokens, uint8/int8 overflow, 10KB+ strings
  - Token count mismatch: fewer/more tokens than format
  - Separator variants: tab, pipe, quoted values with separators inside
  - Concurrency: parallel ParseLine with shared Parser (verified with `-race`)
  - Parser reuse: no state leak across 1000 calls, clean struct overwrite

- **Extended benchmarks** in `bench_extended_test.go`:
  - By field count (1/5/15/25 fields)
  - By type complexity (all-strings / all-ints / mixed / time-heavy)
  - By line length (23B / 204B / 1004B)
  - Concurrent benchmark with `b.RunParallel`

- **Fix broken `BenchmarkParse`**: time layout was `RFC822` but the entry string format didn't match, causing `time parse` errors on every iteration. Changed to `RFC3339` with matching entry and regex.

- **Fix panic in `extractors.go`**: when a log line has fewer tokens than the format expects, offset could go negative causing a panic. Added bounds check.

## Verification

```bash
GO111MODULE=off go test -v -race -count=1        # all pass, zero races
GO111MODULE=off go test -bench=. -benchmem -count=1 -run=^$  # clean, no errors
```